### PR TITLE
Display Problem In pop up Time Series Grid

### DIFF
--- a/source/tsgrid.pas
+++ b/source/tsgrid.pas
@@ -2401,8 +2401,7 @@ begin
     (ATsRecord.Owner = FFilteredSeries) and
     (Canvas.Brush.Color=clWindow) then
     Canvas.Brush.Color := FFilteredColor;
-  ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2, ETO_CLIPPED or
-    ETO_OPAQUE, @ARect, PChar(s), Length(s), nil);
+  ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2, ETO_CLIPPED, @ARect, PChar(s), Length(s), nil);
   Canvas.Brush.Color := SavedColor;
   RestoreFont;
 end;


### PR DESCRIPTION
The bug occurred  when a pop up Time series grid was displayed. The first
row and line
was filled with black color. The problem was located in louise in
tsgrid.pas in the
procedure TtimeseriesGrid.DrawCellSimple. I changed the input of the
function

ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2, ETO_CLIPPED or
ETO_OPAQUE, @ARect, PChar(s), Length(s), nil);
  to
ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2, ETO_CLIPPED,
@ARect, PChar(s), Length(s), nil);
