### PR TITLE
Display Problem In pop up DrawCellTable

### DIFF
--- a/source/tsgrid.pas
+++ b/source/tsgrid.pas
@@ -2462,8 +2462,9 @@ begin
       Canvas.Brush.Color := BgColor;
   s := FDisplayedTable[ARow, ACol].DisplayedValue + ' ';
     { The space at the end is for a right border. }
-  ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2, ETO_CLIPPED or
-    ETO_OPAQUE, @ARect, PChar(s), Length(s), nil);
+  //See the big comment in DrawCellSimple
+  ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2, ETO_CLIPPED {or
+    ETO_OPAQUE}, @ARect, PChar(s), Length(s), nil);
   Canvas.Brush.Color := SavedColor;
   RestoreFont;
 end;


### PR DESCRIPTION
The bug occurred  when a pop up Time series grid was displayed. The first
row and line was filled with black color. The problem was located in louise in
tsgrid.pas in the procedure
TTimeseriesGrid.DrawCellTable
I changed the input of the function
ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2, ETO_CLIPPED or
  ETO_OPAQUE, @ARect, PChar(s), Length(s), nil);
  to
ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2, ETO_CLIPPED,
  @ARect, PChar(s), Length(s), nil);
