### PR TITLE
Draw Selected Cells  Correctly

### DIFF
--- a/source/tsgrid.pas
+++ b/source/tsgrid.pas
@@ -2346,6 +2346,7 @@ var
   SavedColor: TColor;
   AStatisticsBgColor: Boolean;
   s: string;
+  temp : integer;
 begin
   s := '';
   SaveFont;
@@ -2433,13 +2434,12 @@ begin
 
     Antonis Christofides and Alexandros Siskos, 2014-11-25.
   }
-
   if canvas.brush.color = ODSTRGRDDEFAULTSELECTEDCELLCOLOR then
-    ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2,
-         ETO_CLIPPED or ETO_OPAQUE, @ARect, PChar(s), Length(s), nil)
+     temp:= ETO_CLIPPED or ETO_OPAQUE
   else
-    ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2,
-         ETO_CLIPPED {or ETO_OPAQUE}, @ARect, PChar(s), Length(s), nil);
+     temp:= ETO_CLIPPED;
+  ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2,
+         temp, @ARect, PChar(s), Length(s), nil);
 
   Canvas.Brush.Color := SavedColor;
   RestoreFont;
@@ -2450,6 +2450,7 @@ var
   ReferencePoint: Integer;
   s: string;
   SavedColor: TColor;
+  temp: integer;
 begin
   SaveFont;
 
@@ -2469,8 +2470,15 @@ begin
   s := FDisplayedTable[ARow, ACol].DisplayedValue + ' ';
     { The space at the end is for a right border. }
   //See the big comment in DrawCellSimple
-  ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2, ETO_CLIPPED {or
-    ETO_OPAQUE}, @ARect, PChar(s), Length(s), nil);
+  //ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2, ETO_CLIPPED {or
+  //  ETO_OPAQUE}, @ARect, PChar(s), Length(s), nil);
+  if canvas.brush.color = ODSTRGRDDEFAULTSELECTEDCELLCOLOR then
+     temp:= ETO_CLIPPED or ETO_OPAQUE
+  else
+     temp:= ETO_CLIPPED;
+  ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2,
+         temp, @ARect, PChar(s), Length(s), nil);
+
   Canvas.Brush.Color := SavedColor;
   RestoreFont;
 end;
@@ -3016,16 +3024,16 @@ begin
   if FFullyInvalidated then
     Reformat;
   if DefaultDrawing then
+  begin
+    if gdSelected	in AState then
+    begin
+      canvas.brush.color := ODSTRGRDDEFAULTSELECTEDCELLCOLOR;
+      canvas.font.color  := ODSTRGRDDEFAULTSELECTEDFONTCOLOR;
+    end;
     if FDisplayFormat = dfSimple then DrawCellSimple(ACol, ARow, ARect)
     else if FDisplayFormat = dfTable then DrawCellTable(ACol, ARow, ARect)
     else Assert(False);
-  if gdSelected	in AState then
-  begin
-    canvas.brush.color := ODSTRGRDDEFAULTSELECTEDCELLCOLOR;
-    canvas.font.color  := ODSTRGRDDEFAULTSELECTEDFONTCOLOR;
-    DrawCellSimple(ACol, ARow, ARect);
-  end
-  else canvas.font.color  := font.color;
+  end;
   if FDisplayFormat = dfSimple then
     if ACol = 0 then
       ColWidths[0] := FFirstColumnDefaultWidth;

--- a/source/tsgrid.pas
+++ b/source/tsgrid.pas
@@ -2433,8 +2433,14 @@ begin
 
     Antonis Christofides and Alexandros Siskos, 2014-11-25.
   }
-  ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2,
-    ETO_CLIPPED {or ETO_OPAQUE}, @ARect, PChar(s), Length(s), nil);
+
+  if canvas.brush.color = ODSTRGRDDEFAULTSELECTEDCELLCOLOR then
+    ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2,
+         ETO_CLIPPED or ETO_OPAQUE, @ARect, PChar(s), Length(s), nil)
+  else
+    ExtTextOut(Canvas.Handle, ReferencePoint, ARect.Top + 2,
+         ETO_CLIPPED {or ETO_OPAQUE}, @ARect, PChar(s), Length(s), nil);
+
   Canvas.Brush.Color := SavedColor;
   RestoreFont;
 end;
@@ -3017,6 +3023,7 @@ begin
   begin
     canvas.brush.color := ODSTRGRDDEFAULTSELECTEDCELLCOLOR;
     canvas.font.color  := ODSTRGRDDEFAULTSELECTEDFONTCOLOR;
+    DrawCellSimple(ACol, ARow, ARect);
   end
   else canvas.font.color  := font.color;
   if FDisplayFormat = dfSimple then


### PR DESCRIPTION
The selected cells in time series grid where not drawn correctly. The problem
was caused, again, because of the weird attitude of  ExtTextOut. I made some
changes in
TtimeseriesGrid.DrawCellSimple
and in
TtimeseriesGrid.DrawCell
and the problem was solved.